### PR TITLE
Fix data types to avoid overflow

### DIFF
--- a/Codeforces/1283A.cpp
+++ b/Codeforces/1283A.cpp
@@ -3,9 +3,10 @@ problem link--> https://codeforces.com/contest/1283/problem/A
 #include <bits/stdc++.h>
 using namespace std;
 typedef long long ll;
+#define int long long
 #define fast ios_base::sync_with_stdio(false); cin.tie(NULL); 
 #define test ll t; cin>>t; while(t--)
-int main() {
+int32_t main() {
 	fast;
 	test{
 	   int h,m,x,y;


### PR DESCRIPTION
int data type required to be converted to long long in order to avoid overflow for values > 1e9.
In that case int main() should also be converted to int32_t main().